### PR TITLE
Build ZIP distribution artefact still supporting Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,55 @@
 [![Build Status](https://dev.azure.com/knotx/Knotx/_apis/build/status/Knotx.knotx-starter-kit?branchName=master)](https://dev.azure.com/knotx/Knotx/_build/latest?definitionId=3&branchName=master)
 
 # Knot.x Starter Kit
-Knot.x Starter Kit is a template project that simplifies Knot.x project setup. It allows you to 
+Starter Kit is a template project that simplifies Knot.x project setup. It allows you to 
 customize the [Knot.x distribution](https://github.com/Knotx/knotx-stack) with your own modules and
-configuration entries. Then it builds and validates your custom Docker image. 
+configuration entries. 
 
+Starter Kit artifacts (see the build/distributions folder) are: 
+- a ZIP file when `./gradlew build-stack` or `./gradlew build`
+- a custom Docker image when `./gradlew build-docker`
 
-## How to build
+### Prerequisites
+Follow [Development process](https://github.com/Knotx/knotx-aggregator) instructions to build all 
+SNAPSHOT artifacts.
+
+## How to build & run
 To start a new Knot.x project simply download the chosen ZIP version from https://github.com/Knotx/knotx-starter-kit/tags.
-To use the latest DEV version download this [ZIP](https://github.com/Knotx/knotx-starter-kit/archive/master.zip) and [switch to SNAPSHOT version](https://github.com/Knotx/knotx-starter-kit#how-to-work-with-snapshot).
 
+### ZIP file
 In the unziped folder run
 ```
-$> ./gradlew build
+$> ./gradlew build-stack
+```
+to:
+- build all your custom Knot.x modules
+- download Knot.x Stack artifact, add all required dependencies (including your custom modules and 
+its transitive dependencies), override configs with `/knotx/config`
+- build the custom ZIP artifact
+
+Then, go to the `build/distributions` directory, unzip the ZIP artifact, start Knot.x:
+```
+chmod +x bin/knotx
+bin/knotx run-knotx
+```
+
+and validate urls:
+- [localhost:8092/api/v1/example](http://localhost:8092/api/v1/example)
+- [localhost:8092/api/v2/example](http://localhost:8092/api/v2/example)
+
+### Docker
+In the unziped folder run
+```
+$> ./gradlew build-docker
 ```
 
 to:
 - build all your custom Knot.x modules
 - prepare your custom Docker image with all required dependencies (including your custom modules and 
-its transitive dependencies)
-- validate your Docker image with system tests
+its transitive dependencies) and configs
+- **validate your Docker image with system tests**
 
-## How to run
-Start Docker container
+Then, start Docker container:
 ```
 docker run -p8092:8092 knotx/knotx-starter-kit
 ```
@@ -30,32 +57,6 @@ docker run -p8092:8092 knotx/knotx-starter-kit
 and validate urls:
 - [localhost:8092/api/v1/example](http://localhost:8092/api/v1/example)
 - [localhost:8092/api/v2/example](http://localhost:8092/api/v2/example)
-
-## How to debug
-
-#### Normal debugging
-Edit `Dockerfile` in `docker` folder by adding
-```dockerfile
-RUN sed -i 's/# JVM_DEBUG=/JVM_DEBUG=/g' /usr/local/knotx/bin/knotx
-```
-Start Docker container with additional port
-```cmd
-docker run -p8092:8092 -p18092:18092 knotx/knotx-starter-kit
-```
-
-#### Startup debugging - use this when debugging `start()` methods
-In addition to above edit `Dockerfile` by adding
-```dockerfile
-RUN sed -i 's/suspend=n/suspend=y/g' /usr/local/knotx/bin/knotx
-```
-
-Comment out health-check section from `Dockerfile`
-```dockerfile
-#HEALTHCHECK --interval=5s --timeout=2s --retries=12 \
-#  CMD curl --silent --fail localhost:8092/healthcheck || exit 1
-```
-
-**IMPORTANT !** - Make sure that `CMD [ "knotx", "run-knotx" ]` is a last command in `Dockerfile`
 
 ## What does it contain
 
@@ -94,9 +95,31 @@ dependencies {
 [Dockerfile](https://github.com/Knotx/knotx-starter-kit/blob/master/docker/Dockerfile) is defined 
 in the `docker` folder and extends the [Base Knot.x Docker image](https://hub.docker.com/r/knotx/knotx).
 
-##  How to work with SNAPSHOT
+## How to debug
 
-You need to build SNAPSHOT Docker image locally. The easiest approach is to use [Knot.x Aggregator](https://github.com/Knotx/knotx-aggregator)
-to clone and build all Knot.x modules. Then you need to build base [Knot.x Docker](https://github.com/Knotx/knotx-docker) image.
+### ZIP distribution
+Simply uncomment `# JVM_DEBUG` line in the `bin/knotx` starting script.
 
-Now you can update `gradle.properties` with SNAPSHOT version.
+### Docker debugging
+Edit `Dockerfile` in `docker` folder by adding
+```dockerfile
+RUN sed -i 's/# JVM_DEBUG=/JVM_DEBUG=/g' /usr/local/knotx/bin/knotx
+```
+Start Docker container with additional port
+```cmd
+docker run -p8092:8092 -p18092:18092 knotx/knotx-starter-kit
+```
+
+#### Startup debugging - use this when debugging `start()` methods
+In addition to above edit `Dockerfile` by adding
+```dockerfile
+RUN sed -i 's/suspend=n/suspend=y/g' /usr/local/knotx/bin/knotx
+```
+
+Comment out health-check section from `Dockerfile`
+```dockerfile
+#HEALTHCHECK --interval=5s --timeout=2s --retries=12 \
+#  CMD curl --silent --fail localhost:8092/healthcheck || exit 1
+```
+
+**IMPORTANT !** - Make sure that `CMD [ "knotx", "run-knotx" ]` is a last command in `Dockerfile`

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Starter Kit is a template project that simplifies Knot.x project setup. It allow
 customize the [Knot.x distribution](https://github.com/Knotx/knotx-stack) with your own modules and
 configuration entries. 
 
-Starter Kit artifacts (see the build/distributions folder) are: 
+Starter Kit artefacts (see the build/distributions folder) are: 
 - a ZIP file when `./gradlew build-stack` or `./gradlew build`
 - a custom Docker image when `./gradlew build-docker`
 
 ### Prerequisites
 Follow [Development process](https://github.com/Knotx/knotx-aggregator) instructions to build all 
-SNAPSHOT artifacts.
+SNAPSHOT artefacts.
 
 ## How to build & run
 To start a new Knot.x project simply download the chosen ZIP version from https://github.com/Knotx/knotx-starter-kit/tags.
@@ -23,11 +23,11 @@ $> ./gradlew build-stack
 ```
 to:
 - build all your custom Knot.x modules
-- download Knot.x Stack artifact, add all required dependencies (including your custom modules and 
+- download Knot.x Stack artefact, add all required dependencies (including your custom modules and 
 its transitive dependencies), override configs with `/knotx/config`
-- build the custom ZIP artifact
+- build the custom ZIP artefact
 
-Then, go to the `build/distributions` directory, unzip the ZIP artifact, start Knot.x:
+Then, go to the `build/distributions` directory, unzip the ZIP artefact, start Knot.x:
 ```
 chmod +x bin/knotx
 bin/knotx run-knotx

--- a/README.md
+++ b/README.md
@@ -5,29 +5,28 @@ Starter Kit is a template project that simplifies Knot.x project setup. It allow
 customize the [Knot.x distribution](https://github.com/Knotx/knotx-stack) with your own modules and
 configuration entries. 
 
-Starter Kit artefacts (see the build/distributions folder) are: 
+Starter Kit artifacts (see the build/distributions folder) are: 
 - a ZIP file when `./gradlew build-stack` or `./gradlew build`
 - a custom Docker image when `./gradlew build-docker`
 
-### Prerequisites
-Follow [Development process](https://github.com/Knotx/knotx-aggregator) instructions to build all 
-SNAPSHOT artefacts.
-
 ## How to build & run
-To start a new Knot.x project simply download the chosen ZIP version from https://github.com/Knotx/knotx-starter-kit/tags.
+To start a new Knot.x project simply download the chosen ZIP version from https://github.com/Knotx/knotx-starter-kit/tags
+or use the development one (from the `master` branch). Follow [Development process](https://github.com/Knotx/knotx-aggregator) 
+instructions when use the development version.
 
-### ZIP file
-In the unziped folder run
+Then unzip Starter Kit and run:
+
+### Build ZIP distribution
 ```
 $> ./gradlew build-stack
 ```
 to:
 - build all your custom Knot.x modules
-- download Knot.x Stack artefact, add all required dependencies (including your custom modules and 
+- download Knot.x Stack artifact, add all required dependencies (including your custom modules and 
 its transitive dependencies), override configs with `/knotx/config`
-- build the custom ZIP artefact
+- build the custom ZIP artifact
 
-Then, go to the `build/distributions` directory, unzip the ZIP artefact, start Knot.x:
+Then, go to the `build/distributions` directory, unzip the ZIP artifact, start Knot.x:
 ```
 chmod +x bin/knotx
 bin/knotx run-knotx
@@ -37,8 +36,7 @@ and validate urls:
 - [localhost:8092/api/v1/example](http://localhost:8092/api/v1/example)
 - [localhost:8092/api/v2/example](http://localhost:8092/api/v2/example)
 
-### Docker
-In the unziped folder run
+### Build & validate Docker image
 ```
 $> ./gradlew build-docker
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 # Gradle
 # Build your Java project and run tests with Gradle using a Gradle wrapper script.
-# Add steps that analyze code, save build artifacts, deploy, and more:
+# Add steps that analyze code, save build artefacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 trigger:
@@ -36,5 +36,9 @@ steps:
     displayName: "Build Docker image"
   - script: |
       cd knotx-repos/knotx-starter-kit
-      ./gradlew build
-    displayName: "Build Starter Kit"
+      ./gradlew build-stack
+    displayName: "Build Starter Kit: ZIP"
+  - script: |
+      cd knotx-repos/knotx-starter-kit
+      ./gradlew build-docker
+    displayName: "Build Starter Kit: Docker"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 # Gradle
 # Build your Java project and run tests with Gradle using a Gradle wrapper script.
-# Add steps that analyze code, save build artefacts, deploy, and more:
+# Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 trigger:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,6 @@ tasks.named("build") {
 
 tasks.register("build-docker") {
     group = "docker"
-    // https://github.com/Knotx/knotx-gradle-plugins/blob/master/src/main/kotlin/io/knotx/distribution.gradle.kts
     dependsOn("runTest")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,20 @@ allprojects {
 }
 
 tasks.named("build") {
+    dependsOn("build-stack")
+}
+
+tasks.register("build-docker") {
+    group = "docker"
+    // https://github.com/Knotx/knotx-gradle-plugins/blob/master/src/main/kotlin/io/knotx/distribution.gradle.kts
     dependsOn("runTest")
+}
+
+tasks.register("build-stack") {
+    group = "stack"
+    // https://github.com/Knotx/knotx-gradle-plugins/blob/master/src/main/kotlin/io/knotx/distribution.gradle.kts
+    dependsOn("assembleCustomDistribution")
+    mustRunAfter("build-docker")
 }
 
 apply(from = "gradle/javaAndUnitTests.gradle.kts")


### PR DESCRIPTION
Build ZIP distribution artefact when Docker is not used.

## Description
Two options should be possible:
```
./gradlew build-stack
./gradlew build-docker
```

## Motivation and Context
The Starter Kit project will be used by projects using Docker and not. 

## Upgrade notes (if appropriate)
Remove:
```
tasks.named("build") {
    dependsOn("runTest")
}
```

and add:
```
tasks.named("build") {
    dependsOn("build-stack")
}

tasks.register("build-docker") {
    group = "docker"
    dependsOn("runTest")
}

tasks.register("build-stack") {
    group = "stack"
    // https://github.com/Knotx/knotx-gradle-plugins/blob/master/src/main/kotlin/io/knotx/distribution.gradle.kts
    dependsOn("assembleCustomDistribution")
    mustRunAfter("build-docker")
}
```
in `build.gradle.kts`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
