### PR TITLE
#15 Update Knot.x version and apply API changes.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=0.0.1-SNAPSHOT
 # Knot.x Docker image version (https://hub.docker.com/r/knotx/knotx)
-knotx.version=2.1.0
+knotx.version=2.1.1-SNAPSHOT
 knotx.conf=knotx
 docker.image.name=knotx/knotx-starter-kit
 releasable=false

--- a/modules/example-action/src/main/java/com/project/example/action/ExampleActionFactory.java
+++ b/modules/example-action/src/main/java/com/project/example/action/ExampleActionFactory.java
@@ -1,9 +1,12 @@
 package com.project.example.action;
 
+import static io.knotx.fragments.engine.api.node.single.FragmentResult.SUCCESS_TRANSITION;
+
 import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.engine.api.node.single.FragmentResult;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.ActionFactory;
-import io.knotx.fragments.handler.api.domain.FragmentResult;
+
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -22,7 +25,7 @@ public class ExampleActionFactory implements ActionFactory {
       fragment.appendPayload("message", "Hello from example action!");
       fragment.appendPayload("status", "success");
       Future<FragmentResult> resultFuture = Future
-          .succeededFuture(new FragmentResult(fragment, FragmentResult.SUCCESS_TRANSITION));
+          .succeededFuture(new FragmentResult(fragment, SUCCESS_TRANSITION));
       resultFuture.setHandler(resultHandler);
     };
   }


### PR DESCRIPTION
Update Knot.x version and apply API changes related to https://github.com/Knotx/knotx-fragments/pull/106.

## Upgrade notes
Update dependencies from `io.knotx.fragments.handler.api.domain.FragmentResult` to `io.knotx.fragments.engine.api.node.single.FragmentResult`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
