### PR TITLE
Remove deprecated Gradle task: runTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-server-http` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-41](https://github.com/Knotx/knotx-starter-kit/pull/41) - Remove deprecated Gradle task: `runTest`.
                 
 ## 2.3.0
                 

--- a/gradle/docker.gradle.kts
+++ b/gradle/docker.gradle.kts
@@ -85,11 +85,6 @@ tasks.register<DockerStopContainer>("stopContainer") {
     targetContainerId(createContainer.get().containerId)
 }
 
-/** Deprecated */
-tasks.register("runTest", Test::class) {
-    dependsOn(tasks.named("runFunctionalTest"))
-}
-
 tasks.register("runFunctionalTest", Test::class) {
     group = "docker-functional-tests"
     dependsOn(tasks.named("waitContainer"))


### PR DESCRIPTION
<!-- Please update the sections below that apply, remove the rest -->

## Description
Remove Gradle task: `runTest`.

## Motivation and Context
Clean deprecated APIs.

## Upgrade notes (if appropriate)
Use `runFunctionalTest` instead of `runTest`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
